### PR TITLE
Modernizing the code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An object oriented library for dealing with WordPress options and caching.
 ## Requirements
 
 *   PHP 7.4.0 or above
-*   WordPress 6.0 or higher
+*   WordPress 6.2 or higher (for the `%i` placeholder for `wpdb::prepare`)
 
 ## Installation
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress plugins.</description>
 
-	<config name="minimum_supported_wp_version" value="6.0"/>
+	<config name="minimum_supported_wp_version" value="6.2"/>
 	<config name="testVersion" value="7.4-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=mundschenk-at_wp-data-storage
+sonar.organization=mundschenk-at
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=wp-data-storage
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src
+sonar.inclusions=src/*.php
+# sonar.exclusions=admin/**/js/*.js,public/js/**/*.js
+sonar.tests=tests
+sonar.test.exclusions=tests/phpstan/*.php
+sonar.php.coverage.reportPaths=build/logs/phpunit.coverage.xml
+sonar.php.tests.reportPath=build/logs/phpunit.test-report.xml
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/src/class-abstract-cache.php
+++ b/src/class-abstract-cache.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,21 +38,21 @@ abstract class Abstract_Cache {
 	 *
 	 * @var int
 	 */
-	protected $incrementor;
+	protected int $incrementor;
 
 	/**
 	 * The prefix added to all keys.
 	 *
 	 * @var string
 	 */
-	private $prefix;
+	private string $prefix;
 
 	/**
 	 * Create new cache instance.
 	 *
 	 * @param string $prefix The prefix automatically added to cache keys.
 	 */
-	public function __construct( $prefix ) {
+	public function __construct( string $prefix ) {
 		$this->prefix = $prefix;
 
 		if ( empty( $this->incrementor ) ) {
@@ -65,7 +65,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return void
 	 */
-	abstract public function invalidate();
+	abstract public function invalidate(): void;
 
 	/**
 	 * Retrieves a cached value.
@@ -74,7 +74,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	abstract public function get( $key );
+	abstract public function get( string $key );
 
 	/**
 	 * Sets an entry in the cache and stores the key.
@@ -85,7 +85,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	abstract public function set( $key, $value, $duration = 0 );
+	abstract public function set( string $key, $value, int $duration = 0 ): bool;
 
 	/**
 	 * Deletes an entry from the cache.
@@ -94,7 +94,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	abstract public function delete( $key );
+	abstract public function delete( string $key ): bool;
 
 	/**
 	 * Retrieves the complete key to use.
@@ -103,7 +103,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return string
 	 */
-	protected function get_key( $key ) {
+	protected function get_key( string $key ): string {
 		return "{$this->prefix}{$this->incrementor}_{$key}";
 	}
 
@@ -112,7 +112,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return string
 	 */
-	protected function get_prefix() {
+	protected function get_prefix(): string {
 		return $this->prefix;
 	}
 }

--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,14 +38,14 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @var string
 	 */
-	private $incrementor_key;
+	private string $incrementor_key;
 
 	/**
 	 * The cache group.
 	 *
 	 * @var string
 	 */
-	private $group;
+	private string $group;
 
 	/**
 	 * Create new cache instance.
@@ -53,11 +53,10 @@ class Cache extends Abstract_Cache {
 	 * @param string      $prefix The prefix automatically added to cache keys.
 	 * @param string|null $group  Optional. The cache group. Defaults to $prefix.
 	 */
-	public function __construct( $prefix, $group = null ) {
-
-		$this->group           = ! isset( $group ) ? $prefix : $group;
+	public function __construct( string $prefix, ?string $group = null ) {
+		$this->group           = $group ?? $prefix;
 		$this->incrementor_key = "{$prefix}cache_incrementor";
-		$this->incrementor     = (int) \wp_cache_get( $this->incrementor_key, $this->group );
+		$this->incrementor     = (int) \wp_cache_get( $this->incrementor_key, $this->group ); // @phpstan-ignore cast.int
 
 		parent::__construct( $prefix );
 	}
@@ -65,7 +64,7 @@ class Cache extends Abstract_Cache {
 	/**
 	 * Invalidate all cached elements by reseting the incrementor.
 	 */
-	public function invalidate() {
+	public function invalidate(): void {
 		$this->incrementor = time();
 		\wp_cache_set( $this->incrementor_key, $this->incrementor, $this->group, 0 );
 	}
@@ -78,7 +77,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, &$found = null ) {
+	public function get( string $key, ?bool &$found = null ) {
 		return \wp_cache_get( $this->get_key( $key ), $this->group, false, $found );
 	}
 
@@ -91,7 +90,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0 ) {
+	public function set( string $key, $value, int $duration = 0 ): bool {
 		return \wp_cache_set( $this->get_key( $key ), $value, $this->group, $duration );
 	}
 
@@ -102,7 +101,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key ) {
+	public function delete( string $key ): bool {
 		return \wp_cache_delete( $this->get_key( $key ), $this->group );
 	}
 }

--- a/src/class-network-options.php
+++ b/src/class-network-options.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -55,16 +55,18 @@ class Network_Options extends Options {
 	/**
 	 * Retrieves an option value.
 	 *
-	 * @param string $option  The option name (without the plugin-specific prefix).
-	 * @param mixed  $default Optional. Default value to return if the option does not exist. Default null.
-	 * @param bool   $raw     Optional. Use the raw option name (i.e. don't call get_name). Default false.
+	 * @since 2.0.0 Parameter `$default` renamed to `$default_value`.
+	 *
+	 * @param string $option        The option name (without the plugin-specific prefix).
+	 * @param mixed  $default_value Optional. Default value to return if the option does not exist. Default null.
+	 * @param bool   $raw           Optional. Use the raw option name (i.e. don't call get_name). Default false.
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $default = null, $raw = false ) {
-		$value = \get_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $default );
+	public function get( $option, $default_value = null, $raw = false ) {
+		$value = \get_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $default_value );
 
-		if ( is_array( $default ) && '' === $value ) {
+		if ( is_array( $default_value ) && '' === $value ) {
 			$value = [];
 		}
 

--- a/src/class-network-options.php
+++ b/src/class-network-options.php
@@ -38,7 +38,7 @@ class Network_Options extends Options {
 	 *
 	 * @var int
 	 */
-	private $network_id;
+	private int $network_id;
 
 	/**
 	 * Create new Network Options instance.
@@ -46,8 +46,8 @@ class Network_Options extends Options {
 	 * @param string   $prefix     The prefix automatically added to option names.
 	 * @param int|null $network_id Optional. The network ID or null for the current network. Default null.
 	 */
-	public function __construct( $prefix, $network_id = null ) {
-		$this->network_id = ! empty( $network_id ) ? $network_id : \get_current_network_id();
+	public function __construct( string $prefix, ?int $network_id = null ) {
+		$this->network_id = $network_id ?? \get_current_network_id();
 
 		parent::__construct( $prefix );
 	}
@@ -63,7 +63,7 @@ class Network_Options extends Options {
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $default_value = null, $raw = false ) {
+	public function get( string $option, $default_value = null, bool $raw = false ) {
 		$value = \get_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $default_value );
 
 		if ( is_array( $default_value ) && '' === $value ) {
@@ -84,7 +84,7 @@ class Network_Options extends Options {
 	 *
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
-	public function set( $option, $value, $autoload = true, $raw = false ) {
+	public function set( string $option, $value, bool $autoload = true, bool $raw = false ): bool {
 		return \update_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $value );
 	}
 
@@ -96,7 +96,7 @@ class Network_Options extends Options {
 	 *
 	 * @return bool True, if option is successfully deleted. False on failure.
 	 */
-	public function delete( $option, $raw = false ) {
+	public function delete( string $option, bool $raw = false ): bool {
 		return \delete_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ) );
 	}
 }

--- a/src/class-options.php
+++ b/src/class-options.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,16 +52,18 @@ class Options {
 	/**
 	 * Retrieves an option value.
 	 *
-	 * @param string $option  The option name (without the plugin-specific prefix).
-	 * @param mixed  $default Optional. Default value to return if the option does not exist. Default null.
-	 * @param bool   $raw     Optional. Use the raw option name (i.e. don't call get_name). Default false.
+	 * @since 2.0.0 Parameter `$default` renamed to `$default_value`.
+	 *
+	 * @param string $option        The option name (without the plugin-specific prefix).
+	 * @param mixed  $default_value Optional. Default value to return if the option does not exist. Default null.
+	 * @param bool   $raw           Optional. Use the raw option name (i.e. don't call get_name). Default false.
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $default = null, $raw = false ) {
-		$value = \get_option( $raw ? $option : $this->get_name( $option ), $default );
+	public function get( $option, $default_value = null, $raw = false ) {
+		$value = \get_option( $raw ? $option : $this->get_name( $option ), $default_value );
 
-		if ( is_array( $default ) && '' === $value ) {
+		if ( is_array( $default_value ) && '' === $value ) {
 			$value = [];
 		}
 

--- a/src/class-options.php
+++ b/src/class-options.php
@@ -38,14 +38,14 @@ class Options {
 	 *
 	 * @var string
 	 */
-	private $prefix;
+	private string $prefix;
 
 	/**
 	 * Create new Options instance.
 	 *
 	 * @param string $prefix The prefix automatically added to option names.
 	 */
-	public function __construct( $prefix ) {
+	public function __construct( string $prefix ) {
 		$this->prefix = $prefix;
 	}
 
@@ -60,7 +60,7 @@ class Options {
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $default_value = null, $raw = false ) {
+	public function get( string $option, $default_value = null, bool $raw = false ) {
 		$value = \get_option( $raw ? $option : $this->get_name( $option ), $default_value );
 
 		if ( is_array( $default_value ) && '' === $value ) {
@@ -83,7 +83,7 @@ class Options {
 	 *
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
-	public function set( $option, $value, $autoload = true, $raw = false ) {
+	public function set( string $option, $value, bool $autoload = true, bool $raw = false ) {
 		return \update_option( $raw ? $option : $this->get_name( $option ), $value, $autoload );
 	}
 
@@ -95,7 +95,7 @@ class Options {
 	 *
 	 * @return bool True, if option is successfully deleted. False on failure.
 	 */
-	public function delete( $option, $raw = false ) {
+	public function delete( string $option, bool $raw = false ): bool {
 		return \delete_option( $raw ? $option : $this->get_name( $option ) );
 	}
 
@@ -106,7 +106,7 @@ class Options {
 	 *
 	 * @return string
 	 */
-	public function get_name( $option ) {
+	public function get_name( string $option ): string {
 		return "{$this->prefix}{$option}";
 	}
 }

--- a/src/class-site-transients.php
+++ b/src/class-site-transients.php
@@ -52,14 +52,14 @@ class Site_Transients extends Transients {
 		 */
 		global $wpdb;
 
-		$results = $wpdb->get_results(
+		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key like %s and site_id = %d",
 				self::TRANSIENT_SQL_PREFIX . "{$this->get_prefix()}%",
 				\get_current_network_id()
 			),
 			ARRAY_A
-		); // WPCS: db call ok, cache ok.
+		);
 
 		return \str_replace( self::TRANSIENT_SQL_PREFIX, '', \wp_list_pluck( $results, 'meta_key' ) );
 	}

--- a/src/class-site-transients.php
+++ b/src/class-site-transients.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -39,7 +39,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return string[]
 	 */
-	public function get_keys_from_database() {
+	public function get_keys_from_database(): array {
 		// If we are not running on multisite, fall back to the parent implementation.
 		if ( ! is_multisite() ) {
 			return parent::get_keys_from_database();
@@ -73,7 +73,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, $raw = false ) {
+	public function get( string $key, bool $raw = false ) {
 		return \get_site_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 
@@ -87,7 +87,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0, $raw = false ) {
+	public function set( string $key, $value, int $duration = 0, bool $raw = false ): bool {
 		return \set_site_transient( $raw ? $key : $this->get_key( $key ), $value, $duration );
 	}
 
@@ -99,7 +99,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key, $raw = false ) {
+	public function delete( string $key, bool $raw = false ): bool {
 		return \delete_site_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 }

--- a/src/class-site-transients.php
+++ b/src/class-site-transients.php
@@ -54,7 +54,8 @@ class Site_Transients extends Transients {
 
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key like %s and site_id = %d",
+				'SELECT meta_key FROM %i WHERE meta_key like %s and site_id = %d',
+				$wpdb->sitemeta,
 				self::TRANSIENT_SQL_PREFIX . "{$this->get_prefix()}%",
 				\get_current_network_id()
 			),

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2019 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -179,18 +179,20 @@ class Transients extends Abstract_Cache {
 	/**
 	 * Tries to fix object cache implementations sometimes returning __PHP_Incomplete_Class.
 	 *
+	 * @since 2.0.0 Parameter `$object` renamed to `$maybe_object`.
+	 *
 	 * Originally based on http://stackoverflow.com/a/1173769/6646342 and refactored
 	 * for PHP 7.2 compatibility.
 	 *
-	 * @param  object $object An object that should have been unserialized, but may be of __PHP_Incomplete_Class.
+	 * @param  object $maybe_object An object that should have been unserialized, but may be of __PHP_Incomplete_Class.
 	 *
-	 * @return object         The object with its real class.
+	 * @return object               The object with its real class.
 	 */
-	protected function maybe_fix_object( $object ) {
-		if ( '__PHP_Incomplete_Class' === \get_class( $object ) ) {
-			$object = \unserialize( \serialize( $object ) ); // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize,WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	protected function maybe_fix_object( $maybe_object ) {
+		if ( '__PHP_Incomplete_Class' === \get_class( $maybe_object ) ) {
+			$maybe_object = \unserialize( \serialize( $maybe_object ) ); // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize,WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		}
 
-		return $object;
+		return $maybe_object;
 	}
 }

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -40,7 +40,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @var string
 	 */
-	protected $incrementor_key;
+	protected string $incrementor_key;
 
 	/**
 	 * Create new cache instance.
@@ -49,7 +49,7 @@ class Transients extends Abstract_Cache {
 	 */
 	public function __construct( $prefix ) {
 		$this->incrementor_key = $prefix . 'transients_incrementor';
-		$this->incrementor     = $this->get( $this->incrementor_key, true );
+		$this->incrementor     = (int) $this->get( $this->incrementor_key, true ); // @phpstan-ignore cast.int
 
 		parent::__construct( $prefix );
 	}
@@ -57,7 +57,7 @@ class Transients extends Abstract_Cache {
 	/**
 	 * Invalidate all cached elements by reseting the incrementor.
 	 */
-	public function invalidate() {
+	public function invalidate(): void {
 
 		if ( ! \wp_using_ext_object_cache() ) {
 			// Clean up old transients.
@@ -76,7 +76,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return string[]
 	 */
-	public function get_keys_from_database() {
+	public function get_keys_from_database(): array {
 		/**
 		 * WordPress database handler.
 		 *
@@ -104,7 +104,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, $raw = false ) {
+	public function get( string $key, bool $raw = false ) {
 		return \get_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 
@@ -115,7 +115,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	public function get_large_object( $key ) {
+	public function get_large_object( string $key ) {
 		$encoded = $this->get( $key );
 		if ( false === $encoded ) {
 			return false;
@@ -139,7 +139,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0, $raw = false ) {
+	public function set( string $key, $value, int $duration = 0, bool $raw = false ): bool {
 		return \set_transient( $raw ? $key : $this->get_key( $key ), $value, $duration );
 	}
 
@@ -153,7 +153,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set_large_object( $key, $value, $duration = 0 ) {
+	public function set_large_object( string $key, $value, int $duration = 0 ): bool {
 		$compressed = \gzencode( \serialize( $value ) ); // @codingStandardsIgnoreLine
 
 		if ( false === $compressed ) {
@@ -173,7 +173,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key, $raw = false ) {
+	public function delete( string $key, bool $raw = false ): bool {
 		return \delete_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -86,7 +86,8 @@ class Transients extends Abstract_Cache {
 
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"SELECT option_name FROM {$wpdb->options} WHERE option_name like %s",
+				'SELECT option_name FROM %i WHERE option_name like %s',
+				$wpdb->options,
 				static::TRANSIENT_SQL_PREFIX . "{$this->get_prefix()}%"
 			),
 			ARRAY_A

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -84,13 +84,13 @@ class Transients extends Abstract_Cache {
 		 */
 		global $wpdb;
 
-		$results = $wpdb->get_results(
+		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT option_name FROM {$wpdb->options} WHERE option_name like %s",
 				static::TRANSIENT_SQL_PREFIX . "{$this->get_prefix()}%"
 			),
 			ARRAY_A
-		); // WPCS: db call ok, cache ok.
+		);
 
 		return \str_replace( static::TRANSIENT_SQL_PREFIX, '', \wp_list_pluck( $results, 'option_name' ) );
 	}

--- a/tests/class-network-options-test.php
+++ b/tests/class-network-options-test.php
@@ -63,8 +63,7 @@ class Network_Options_Test extends TestCase {
 	 * This method is called before a test is executed.
 	 */
 	protected function set_up() {
-		$this->options = m::mock( Network_Options::class )->makePartial();
-		$this->set_value( $this->options, 'network_id', self::NETWORK_ID, Network_Options::class );
+		$this->options = m::mock( Network_Options::class, [ 'my_prefix_', self::NETWORK_ID ] )->makePartial();
 
 		parent::set_up();
 	}

--- a/tests/class-options-test.php
+++ b/tests/class-options-test.php
@@ -55,7 +55,7 @@ class Options_Test extends TestCase {
 	 * This method is called before a test is executed.
 	 */
 	protected function set_up() { // @codingStandardsIgnoreLine
-		$this->options = m::mock( Options::class )->makePartial();
+		$this->options = m::mock( Options::class, [ 'my_prefix_' ] )->makePartial();
 
 		parent::set_up();
 	}

--- a/tests/class-site-transients-test.php
+++ b/tests/class-site-transients-test.php
@@ -244,8 +244,8 @@ class Site_Transients_Test extends TestCase {
 
 		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( \base64_encode( \gzencode( \serialize( new \stdClass() ) ) ) ); // @codingStandardsIgnoreLine
 		$this->transients->shouldReceive( 'maybe_fix_object' )->once()->with( m::type( \stdClass::class ) )->andReturnUsing(
-			function( $object ) {
-				return $object;
+			static function ( object $o ): object {
+				return $o;
 			}
 		);
 

--- a/tests/class-site-transients-test.php
+++ b/tests/class-site-transients-test.php
@@ -145,7 +145,7 @@ class Site_Transients_Test extends TestCase {
 		Functions\expect( 'is_multisite' )->once()->andReturn( true );
 
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
-		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), Site_Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%', 1 )->andReturn( 'fake SQL string' );
+		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), $wpdb->sitemeta, Site_Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%', 1 )->andReturn( 'fake SQL string' );
 		$wpdb->shouldReceive( 'get_results' )->with( 'fake SQL string', ARRAY_A )->andReturn( $dummy_result );
 
 		Functions\expect( 'get_current_network_id' )->once()->with()->andReturn( 1 );
@@ -176,7 +176,7 @@ class Site_Transients_Test extends TestCase {
 		Functions\expect( 'is_multisite' )->once()->andReturn( false );
 
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
-		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), Site_Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%' )->andReturn( 'fake SQL string' );
+		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), $wpdb->options, Site_Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%' )->andReturn( 'fake SQL string' );
 		$wpdb->shouldReceive( 'get_results' )->with( 'fake SQL string', ARRAY_A )->andReturn( $dummy_result );
 
 		Functions\expect( 'get_current_network_id' )->never();

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -209,8 +209,8 @@ class Transients_Test extends TestCase {
 
 		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( \base64_encode( \gzencode( \serialize( new \stdClass() ) ) ) ); // @codingStandardsIgnoreLine
 		$this->transients->shouldReceive( 'maybe_fix_object' )->once()->with( m::type( \stdClass::class ) )->andReturnUsing(
-			function( $object ) {
-				return $object;
+			static function ( object $o ): object {
+				return $o;
 			}
 		);
 

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -142,7 +142,7 @@ class Transients_Test extends TestCase {
 		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->options = 'wp_options';
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
-		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%' )->andReturn( 'fake SQL string' );
+		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), $wpdb->options, Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%' )->andReturn( 'fake SQL string' );
 		$wpdb->shouldReceive( 'get_results' )->with( 'fake SQL string', ARRAY_A )->andReturn( $dummy_result );
 
 		Functions\expect( 'wp_list_pluck' )->once()->with( $dummy_result, 'option_name' )->andReturn( [ 'typo_foobar' ] );


### PR DESCRIPTION
- Uses new PHPCS syntax for database calls.
- Uses the `%i` placeholder in `wpdb::prepare` calls.
- Adds type declarations.
- Replaces reserved words in parameter and variable names.