### PR TITLE
Refactor Transients::get_large_object to only allow certain classes

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=mundschenk-at_wp-data-storage
+sonar.organization=mundschenk-at
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=wp-data-storage
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src
+sonar.inclusions=src/*.php
+# sonar.exclusions=admin/**/js/*.js,public/js/**/*.js
+sonar.tests=tests
+sonar.test.exclusions=tests/phpstan/*.php
+sonar.php.coverage.reportPaths=build/logs/phpunit.coverage.xml
+sonar.php.tests.reportPath=build/logs/phpunit.test-report.xml
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/tests/class-large-dummy-object.php
+++ b/tests/class-large-dummy-object.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of mundschenk-at/wp-data-storage.
+ *
+ * Copyright 2018-2024 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or ( at your option ) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * @package mundschenk-at/wp-data-storage/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Mundschenk\Data_Storage\Tests;
+
+/**
+ * A dummy class.
+ */
+class Large_Dummy_Object {
+	/**
+	 * A dummy property.
+	 *
+	 * @var int[]
+	 */
+	public array $some_property;
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->some_property = range( 0, 1000 );
+	}
+}

--- a/tests/class-site-transients-test.php
+++ b/tests/class-site-transients-test.php
@@ -240,16 +240,13 @@ class Site_Transients_Test extends TestCase {
 	 * @covers ::get_large_object
 	 */
 	public function test_get_large_object() {
-		$raw_key = 'foo';
+		$raw_key             = 'foo';
+		$unserialized_object = new Large_Dummy_Object();
+		$blob                = \base64_encode( \gzencode( \serialize( $unserialized_object ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( \base64_encode( \gzencode( \serialize( new \stdClass() ) ) ) ); // @codingStandardsIgnoreLine
-		$this->transients->shouldReceive( 'maybe_fix_object' )->once()->with( m::type( \stdClass::class ) )->andReturnUsing(
-			static function ( object $o ): object {
-				return $o;
-			}
-		);
+		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( $blob );
 
-		$this->assertInstanceOf( \stdClass::class, $this->transients->get_large_object( $raw_key ) );
+		$this->assertInstanceOf( Large_Dummy_Object::class, $this->transients->get_large_object( $raw_key, [ Large_Dummy_Object::class ] ) );
 	}
 
 	/**
@@ -262,7 +259,7 @@ class Site_Transients_Test extends TestCase {
 
 		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( false );
 
-		$this->assertFalse( $this->transients->get_large_object( $raw_key ) );
+		$this->assertFalse( $this->transients->get_large_object( $raw_key, [ Large_Dummy_Object::class ] ) );
 	}
 
 	/**
@@ -271,11 +268,28 @@ class Site_Transients_Test extends TestCase {
 	 * @covers ::get_large_object
 	 */
 	public function test_get_large_object_uncompression_failing() {
-		$raw_key = 'foo';
+		$raw_key             = 'foo';
+		$unserialized_object = new Large_Dummy_Object();
+		$blob                = \base64_encode( \serialize( $unserialized_object ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( \base64_encode( \serialize( new \stdClass() ) ) ); // @codingStandardsIgnoreLine
+		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( $blob );
 
-		$this->assertFalse( $this->transients->get_large_object( $raw_key ) );
+		$this->assertFalse( $this->transients->get_large_object( $raw_key, [ Large_Dummy_Object::class ] ) );
+	}
+
+	/**
+	 * Tests get_large_object with failing uncompress.
+	 *
+	 * @covers ::get_large_object
+	 */
+	public function test_get_large_object_invalid_class() {
+		$raw_key             = 'foo';
+		$unserialized_object = new \stdClass();
+		$blob                = \base64_encode( \serialize( $unserialized_object ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
+		$this->transients->shouldReceive( 'get' )->once()->with( $raw_key )->andReturn( $blob );
+
+		$this->assertFalse( $this->transients->get_large_object( $raw_key, [ Large_Dummy_Object::class ] ) );
 	}
 
 	/**
@@ -292,20 +306,5 @@ class Site_Transients_Test extends TestCase {
 		Functions\expect( 'delete_site_transient' )->once()->with( $key )->andReturn( true );
 
 		$this->assertTrue( $this->transients->delete( $raw_key ) );
-	}
-
-	/**
-	 * Test maybe_fix_object.
-	 *
-	 * @covers ::maybe_fix_object
-	 */
-	public function test_maybe_fix_object() {
-		$fake_object_string = 'O:16:"SomeMissingClass":1:{s:1:"a";s:1:"b";}';
-		$fake_object        = unserialize( $fake_object_string ); // @codingStandardsIgnoreLine
-
-		// Unfortunately, serialize and  unserialize cannot be mocked.
-		$object = $this->invoke_method( $this->transients, 'maybe_fix_object', [ $fake_object ] );
-
-		$this->assertTrue( $object !== $fake_object );
 	}
 }


### PR DESCRIPTION
- Removes obsolete method `maybe_fix_objects` (autoloading makes sure that the class exists).
- Restrict retrieved large objects to pre-defined classes.
- Updates the tests.
- Adds `sonar-project.properties`.