### PR TITLE
Additional PHPStan fixes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: max
     inferPrivatePropertyTypeFromConstructor: true
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false

--- a/src/class-abstract-cache.php
+++ b/src/class-abstract-cache.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,14 +38,14 @@ abstract class Abstract_Cache {
 	 *
 	 * @var int
 	 */
-	protected $incrementor;
+	protected int $incrementor;
 
 	/**
 	 * The prefix added to all keys.
 	 *
 	 * @var string
 	 */
-	private $prefix;
+	private string $prefix;
 
 	/**
 	 * Create new cache instance.
@@ -65,7 +65,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return void
 	 */
-	abstract public function invalidate();
+	abstract public function invalidate(): void;
 
 	/**
 	 * Retrieves a cached value.
@@ -74,7 +74,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	abstract public function get( $key );
+	abstract public function get( string $key );
 
 	/**
 	 * Sets an entry in the cache and stores the key.
@@ -85,7 +85,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	abstract public function set( $key, $value, $duration = 0 );
+	abstract public function set( string $key, $value, int $duration = 0 ): bool;
 
 	/**
 	 * Deletes an entry from the cache.
@@ -94,7 +94,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	abstract public function delete( $key );
+	abstract public function delete( string $key ): bool;
 
 	/**
 	 * Retrieves the complete key to use.
@@ -103,7 +103,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return string
 	 */
-	protected function get_key( $key ) {
+	protected function get_key( string $key ): string {
 		return "{$this->prefix}{$this->incrementor}_{$key}";
 	}
 
@@ -112,7 +112,7 @@ abstract class Abstract_Cache {
 	 *
 	 * @return string
 	 */
-	protected function get_prefix() {
+	protected function get_prefix(): string {
 		return $this->prefix;
 	}
 }

--- a/src/class-abstract-cache.php
+++ b/src/class-abstract-cache.php
@@ -61,7 +61,7 @@ abstract class Abstract_Cache {
 	}
 
 	/**
-	 * Invalidate all cached elements by reseting the incrementor.
+	 * Invalidate all cached elements by resetting the incrementor.
 	 *
 	 * @return void
 	 */

--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -57,7 +57,11 @@ class Cache extends Abstract_Cache {
 
 		$this->group           = ! isset( $group ) ? $prefix : $group;
 		$this->incrementor_key = "{$prefix}cache_incrementor";
-		$this->incrementor     = (int) \wp_cache_get( $this->incrementor_key, $this->group );
+
+		$incrementor = \wp_cache_get( $this->incrementor_key, $this->group );
+		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
+
+		$this->incrementor = $incrementor;
 
 		parent::__construct( $prefix );
 	}

--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -25,7 +25,7 @@
 namespace Mundschenk\Data_Storage;
 
 /**
- * Implements an inteface to the WordPress Object Cache.
+ * Implements an interface to the WordPress Object Cache.
  *
  * @since 1.0.0
  *
@@ -67,7 +67,7 @@ class Cache extends Abstract_Cache {
 	}
 
 	/**
-	 * Invalidate all cached elements by reseting the incrementor.
+	 * Invalidate all cached elements by resetting the incrementor.
 	 */
 	public function invalidate(): void {
 		$this->incrementor = time();

--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,14 +38,14 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @var string
 	 */
-	private $incrementor_key;
+	private string $incrementor_key;
 
 	/**
 	 * The cache group.
 	 *
 	 * @var string
 	 */
-	private $group;
+	private string $group;
 
 	/**
 	 * Create new cache instance.
@@ -65,7 +65,7 @@ class Cache extends Abstract_Cache {
 	/**
 	 * Invalidate all cached elements by reseting the incrementor.
 	 */
-	public function invalidate() {
+	public function invalidate(): void {
 		$this->incrementor = time();
 		\wp_cache_set( $this->incrementor_key, $this->incrementor, $this->group, 0 );
 	}
@@ -78,7 +78,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, &$found = null ) {
+	public function get( string $key, ?bool &$found = null ) {
 		return \wp_cache_get( $this->get_key( $key ), $this->group, false, $found );
 	}
 
@@ -91,7 +91,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0 ) {
+	public function set( string $key, $value, int $duration = 0 ): bool {
 		return \wp_cache_set( $this->get_key( $key ), $value, $this->group, $duration );
 	}
 
@@ -102,7 +102,7 @@ class Cache extends Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key ) {
+	public function delete( string $key ): bool {
 		return \wp_cache_delete( $this->get_key( $key ), $this->group );
 	}
 }

--- a/src/class-network-options.php
+++ b/src/class-network-options.php
@@ -38,7 +38,7 @@ class Network_Options extends Options {
 	 *
 	 * @var int
 	 */
-	private $network_id;
+	private int $network_id;
 
 	/**
 	 * Create new Network Options instance.
@@ -58,15 +58,15 @@ class Network_Options extends Options {
 	 * @since 2.0.0 Parameter `$default` renamed to `$default_value`.
 	 *
 	 * @param string $option       The option name (without the plugin-specific prefix).
-	 * @param mixed  $defaul_value Optional. Default value to return if the option does not exist. Default null.
+	 * @param mixed  $default_value Optional. Default value to return if the option does not exist. Default null.
 	 * @param bool   $raw          Optional. Use the raw option name (i.e. don't call get_name). Default false.
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $defaul_value = null, $raw = false ) {
-		$value = \get_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $defaul_value );
+	public function get( string $option, $default_value = null, bool $raw = false ) {
+		$value = \get_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $default_value );
 
-		if ( is_array( $defaul_value ) && '' === $value ) {
+		if ( is_array( $default_value ) && '' === $value ) {
 			$value = [];
 		}
 
@@ -84,7 +84,7 @@ class Network_Options extends Options {
 	 *
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
-	public function set( $option, $value, $autoload = true, $raw = false ) {
+	public function set( string $option, $value, bool $autoload = true, bool $raw = false ): bool {
 		return \update_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ), $value );
 	}
 
@@ -96,7 +96,7 @@ class Network_Options extends Options {
 	 *
 	 * @return bool True, if option is successfully deleted. False on failure.
 	 */
-	public function delete( $option, $raw = false ) {
+	public function delete( string $option, bool $raw = false ): bool {
 		return \delete_network_option( $this->network_id, $raw ? $option : $this->get_name( $option ) );
 	}
 }

--- a/src/class-options.php
+++ b/src/class-options.php
@@ -38,7 +38,7 @@ class Options {
 	 *
 	 * @var string
 	 */
-	private $prefix;
+	private string $prefix;
 
 	/**
 	 * Create new Options instance.
@@ -60,7 +60,7 @@ class Options {
 	 *
 	 * @return mixed Value set for the option.
 	 */
-	public function get( $option, $default_value = null, $raw = false ) {
+	public function get( string $option, $default_value = null, bool $raw = false ) {
 		$value = \get_option( $raw ? $option : $this->get_name( $option ), $default_value );
 
 		if ( is_array( $default_value ) && '' === $value ) {
@@ -83,7 +83,7 @@ class Options {
 	 *
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
-	public function set( $option, $value, $autoload = true, $raw = false ) {
+	public function set( string $option, $value, bool $autoload = true, bool $raw = false ): bool {
 		return \update_option( $raw ? $option : $this->get_name( $option ), $value, $autoload );
 	}
 
@@ -95,7 +95,7 @@ class Options {
 	 *
 	 * @return bool True, if option is successfully deleted. False on failure.
 	 */
-	public function delete( $option, $raw = false ) {
+	public function delete( string $option, bool $raw = false ): bool {
 		return \delete_option( $raw ? $option : $this->get_name( $option ) );
 	}
 
@@ -106,7 +106,7 @@ class Options {
 	 *
 	 * @return string
 	 */
-	public function get_name( $option ) {
+	public function get_name( string $option ): string {
 		return "{$this->prefix}{$option}";
 	}
 }

--- a/src/class-site-transients.php
+++ b/src/class-site-transients.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2024 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -39,7 +39,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return string[]
 	 */
-	public function get_keys_from_database() {
+	public function get_keys_from_database(): array {
 		// If we are not running on multisite, fall back to the parent implementation.
 		if ( ! is_multisite() ) {
 			return parent::get_keys_from_database();
@@ -73,7 +73,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, $raw = false ) {
+	public function get( string $key, bool $raw = false ) {
 		return \get_site_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 
@@ -87,7 +87,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0, $raw = false ) {
+	public function set( string $key, $value, int $duration = 0, bool $raw = false ): bool {
 		return \set_site_transient( $raw ? $key : $this->get_key( $key ), $value, $duration );
 	}
 
@@ -99,7 +99,7 @@ class Site_Transients extends Transients {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key, $raw = false ) {
+	public function delete( string $key, bool $raw = false ): bool {
 		return \delete_site_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 }

--- a/src/class-site-transients.php
+++ b/src/class-site-transients.php
@@ -60,9 +60,16 @@ class Site_Transients extends Transients {
 				\get_current_network_id()
 			),
 			ARRAY_A
-		);
+		) ?? [];
 
-		return \str_replace( self::TRANSIENT_SQL_PREFIX, '', \wp_list_pluck( $results, 'meta_key' ) );
+		/**
+		 * Retrieve the list of transients.
+		 *
+		 * @var string[] $meta_keys
+		 */
+		$meta_keys = \wp_list_pluck( $results, 'meta_key' );
+
+		return \str_replace( self::TRANSIENT_SQL_PREFIX, '', $meta_keys );
 	}
 
 	/**

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -55,7 +55,11 @@ class Transients extends Abstract_Cache {
 	 */
 	public function __construct( string $prefix ) {
 		$this->incrementor_key = $prefix . 'transients_incrementor';
-		$this->incrementor     = $this->get( $this->incrementor_key, true );
+
+		$incrementor = $this->get( $this->incrementor_key, true );
+		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
+
+		$this->incrementor = $incrementor;
 
 		parent::__construct( $prefix );
 	}
@@ -133,7 +137,7 @@ class Transients extends Abstract_Cache {
 	 */
 	public function get_large_object( string $key, array $allowed_classes ) {
 		$encoded = $this->get( $key );
-		if ( false === $encoded ) {
+		if ( ! \is_string( $encoded ) ) {
 			return false;
 		}
 

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -46,14 +46,14 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @var string
 	 */
-	protected $incrementor_key;
+	protected string $incrementor_key;
 
 	/**
 	 * Create new cache instance.
 	 *
 	 * @param string $prefix The prefix automatically added to transient names.
 	 */
-	public function __construct( $prefix ) {
+	public function __construct( string $prefix ) {
 		$this->incrementor_key = $prefix . 'transients_incrementor';
 		$this->incrementor     = $this->get( $this->incrementor_key, true );
 
@@ -63,7 +63,7 @@ class Transients extends Abstract_Cache {
 	/**
 	 * Invalidate all cached elements by reseting the incrementor.
 	 */
-	public function invalidate() {
+	public function invalidate(): void {
 
 		if ( ! \wp_using_ext_object_cache() ) {
 			// Clean up old transients.
@@ -82,7 +82,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return string[]
 	 */
-	public function get_keys_from_database() {
+	public function get_keys_from_database(): array {
 		/**
 		 * WordPress database handler.
 		 *
@@ -110,7 +110,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return mixed
 	 */
-	public function get( $key, $raw = false ) {
+	public function get( string $key, bool $raw = false ) {
 		return \get_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 
@@ -154,7 +154,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return bool True if the cache could be set successfully.
 	 */
-	public function set( $key, $value, $duration = 0, $raw = false ) {
+	public function set( string $key, $value, int $duration = 0, bool $raw = false ): bool {
 		return \set_transient( $raw ? $key : $this->get_key( $key ), $value, $duration );
 	}
 
@@ -188,7 +188,7 @@ class Transients extends Abstract_Cache {
 	 *
 	 * @return bool True on successful removal, false on failure.
 	 */
-	public function delete( $key, $raw = false ) {
+	public function delete( string $key, bool $raw = false ): bool {
 		return \delete_transient( $raw ? $key : $this->get_key( $key ) );
 	}
 }

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -97,9 +97,16 @@ class Transients extends Abstract_Cache {
 				static::TRANSIENT_SQL_PREFIX . "{$this->get_prefix()}%"
 			),
 			ARRAY_A
-		);
+		) ?? [];
 
-		return \str_replace( static::TRANSIENT_SQL_PREFIX, '', \wp_list_pluck( $results, 'option_name' ) );
+		/**
+		 * Retrieve the list of transients.
+		 *
+		 * @var string[] $option_names
+		 */
+		$option_names = \wp_list_pluck( $results, 'option_name' );
+
+		return \str_replace( static::TRANSIENT_SQL_PREFIX, '', $option_names );
 	}
 
 	/**

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -65,7 +65,7 @@ class Transients extends Abstract_Cache {
 	}
 
 	/**
-	 * Invalidate all cached elements by reseting the incrementor.
+	 * Invalidate all cached elements by resetting the incrementor.
 	 */
 	public function invalidate(): void {
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,7 +21,7 @@
  * @package mundschenk-at/wp-data-storage/tests
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  *
- * @version 2.0-alpha.1
+ * @version 2.0.0
  */
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,3 +28,16 @@
  * Autoload everything using Composer.
  */
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! defined( 'ARRAY_N' ) ) {
+	define( 'ARRAY_N', 'ARRAY_N' );
+}
+if ( ! defined( 'OBJECT' ) ) {
+	define( 'OBJECT', 'OBJECT' );
+}
+if ( ! defined( 'OBJECT_K' ) ) {
+	define( 'OBJECT_K', 'OBJECT_K' );
+}

--- a/tests/class-cache-test.php
+++ b/tests/class-cache-test.php
@@ -65,22 +65,47 @@ class Cache_Test extends TestCase {
 	}
 
 	/**
+	 * Provides data for testing ::__construct.
+	 *
+	 * @return array
+	 */
+	public function provide_test__construct_data(): array {
+		return [
+			'valid stored incrementor' => [ 55, 55 ],
+			'no stored incrementor'    => [ false, 0 ],
+			'empty string'             => [ '', 0 ],
+			'non-empty string'         => [ 'something', 0 ],
+			'null'                     => [ null, 0 ],
+			'object'                   => [ new \stdClass(), 0 ],
+			'float'                    => [ 10.5, 0 ],
+			'array'                    => [ [], 0 ],
+		];
+	}
+
+	/**
 	 * Tests constructor.
+	 *
+	 * @dataProvider provide_test__construct_data
 	 *
 	 * @covers ::__construct
 	 *
 	 * @uses \Mundschenk\Data_Storage\Abstract_Cache::__construct
+	 *
+	 * @param  mixed $stored_incrementor   The stored incrementor (return) value.
+	 * @param  int   $expected_incrementor The expected final incrementor value.
+	 *
+	 * @return void
 	 */
-	public function test___construct() {
-		Functions\expect( 'wp_cache_get' )->once()->with( 'some_prefix_cache_incrementor', self::GROUP )->andReturn( 0 );
+	public function test___construct( $stored_incrementor, int $expected_incrementor ) {
+		$cache = m::mock( Cache::class )->makePartial();
 
-		$cache = m::mock( Cache::class )->makePartial()
-			->shouldReceive( 'invalidate' )->once()
-			->getMock();
+		Functions\expect( 'wp_cache_get' )->once()->with( 'some_prefix_cache_incrementor', self::GROUP )->andReturn( $stored_incrementor );
+		$cache->shouldReceive( 'invalidate' )->times( 0 === $expected_incrementor ? 1 : 0 );
 
 		$cache->__construct( 'some_prefix_', self::GROUP );
 
 		$this->assertInstanceOf( Cache::class, $cache );
+		$this->assert_attribute_same( $expected_incrementor, 'incrementor', $cache );
 	}
 
 	/**

--- a/tests/class-network-options-test.php
+++ b/tests/class-network-options-test.php
@@ -63,8 +63,7 @@ class Network_Options_Test extends TestCase {
 	 * This method is called before a test is executed.
 	 */
 	protected function set_up() {
-		$this->options = m::mock( Network_Options::class )->makePartial();
-		$this->set_value( $this->options, 'network_id', self::NETWORK_ID, Network_Options::class );
+		$this->options = m::mock( Network_Options::class, [ 'my-prefix', self::NETWORK_ID ] )->makePartial();
 
 		parent::set_up();
 	}
@@ -77,11 +76,34 @@ class Network_Options_Test extends TestCase {
 	 * @uses \Mundschenk\Data_Storage\Abstract_Cache::__construct
 	 */
 	public function test___construct() {
-		$cache = m::mock( Network_Options::class, [ 'my_prefix', 666 ] )->makePartial();
+		$prefix     = 'some_prefix_';
+		$network_id = 5;
 
-		$this->assertInstanceOf( Network_Options::class, $cache );
-		$this->assert_attribute_same( 'my_prefix', 'prefix', $cache );
-		$this->assert_attribute_same( 666, 'network_id', $cache );
+		$network_options = m::mock( Network_Options::class, [ $prefix, $network_id ] )->makePartial();
+
+		$this->assertInstanceOf( Network_Options::class, $network_options );
+		$this->assert_attribute_same( $prefix, 'prefix', $network_options );
+		$this->assert_attribute_same( $network_id, 'network_id', $network_options );
+	}
+
+	/**
+	 * Tests constructor.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses \Mundschenk\Data_Storage\Abstract_Cache::__construct
+	 */
+	public function test___construct_without_network_id() {
+		$prefix             = 'some_prefix_';
+		$current_network_id = 5;
+
+		Functions\expect( 'get_current_network_id' )->once()->withNoArgs()->andReturn( $current_network_id );
+
+		$network_options = m::mock( Network_Options::class, [ $prefix ] )->makePartial();
+
+		$this->assertInstanceOf( Network_Options::class, $network_options );
+		$this->assert_attribute_same( $prefix, 'prefix', $network_options );
+		$this->assert_attribute_same( $current_network_id, 'network_id', $network_options );
 	}
 
 	/**

--- a/tests/class-options-test.php
+++ b/tests/class-options-test.php
@@ -55,7 +55,7 @@ class Options_Test extends TestCase {
 	 * This method is called before a test is executed.
 	 */
 	protected function set_up() { // @codingStandardsIgnoreLine
-		$this->options = m::mock( Options::class )->makePartial();
+		$this->options = m::mock( Options::class, [ 'my-prefix' ] )->makePartial();
 
 		parent::set_up();
 	}

--- a/tests/class-site-transients-test.php
+++ b/tests/class-site-transients-test.php
@@ -138,10 +138,6 @@ class Site_Transients_Test extends TestCase {
 		$wpdb           = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->sitemeta = 'wp_sitemeta';
 
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
-
 		Functions\expect( 'is_multisite' )->once()->andReturn( true );
 
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
@@ -164,10 +160,6 @@ class Site_Transients_Test extends TestCase {
 		global $wpdb;
 		$wpdb           = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->sitemeta = 'wp_sitemeta';
-
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
 
 		Functions\expect( 'is_multisite' )->once()->andReturn( true );
 
@@ -196,10 +188,6 @@ class Site_Transients_Test extends TestCase {
 		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->options = 'wp_options';
 
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
-
 		Functions\expect( 'is_multisite' )->once()->andReturn( false );
 
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
@@ -224,10 +212,6 @@ class Site_Transients_Test extends TestCase {
 		global $wpdb;
 		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->options = 'wp_options';
-
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
 
 		Functions\expect( 'is_multisite' )->once()->andReturn( false );
 

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -151,6 +151,29 @@ class Transients_Test extends TestCase {
 	}
 
 	/**
+	 * Tests get_keys_from_database with no transients found.
+	 *
+	 * @covers ::get_keys_from_database
+	 */
+	public function test_get_keys_from_database_no_transients() {
+		global $wpdb;
+
+		if ( ! defined( 'ARRAY_A' ) ) {
+			define( 'ARRAY_A', 'array' );
+		}
+
+		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb->options = 'wp_options';
+		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
+		$wpdb->shouldReceive( 'prepare' )->with( m::type( 'string' ), $wpdb->options, Transients::TRANSIENT_SQL_PREFIX . self::PREFIX . '%' )->andReturn( 'fake SQL string' );
+		$wpdb->shouldReceive( 'get_results' )->with( 'fake SQL string', ARRAY_A )->andReturn( null );
+
+		Functions\expect( 'wp_list_pluck' )->once()->with( [], 'option_name' )->andReturn( [] );
+
+		$this->assertSame( [], $this->transients->get_keys_from_database() );
+	}
+
+	/**
 	 * Tests get.
 	 *
 	 * @covers ::get

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -67,20 +67,46 @@ class Transients_Test extends TestCase {
 	}
 
 	/**
+	 * Provides data for testing ::__construct.
+	 *
+	 * @return array
+	 */
+	public function provide_test__construct_data(): array {
+		return [
+			'valid stored incrementor' => [ 55, 55 ],
+			'no stored incrementor'    => [ false, 0 ],
+			'empty string'             => [ '', 0 ],
+			'non-empty string'         => [ 'something', 0 ],
+			'null'                     => [ null, 0 ],
+			'object'                   => [ new \stdClass(), 0 ],
+			'float'                    => [ 10.5, 0 ],
+			'array'                    => [ [], 0 ],
+		];
+	}
+
+	/**
 	 * Tests constructor.
+	 *
+	 * @dataProvider provide_test__construct_data
 	 *
 	 * @covers ::__construct
 	 *
 	 * @uses \Mundschenk\Data_Storage\Abstract_Cache::__construct
+	 *
+	 * @param  mixed $stored_incrementor   The stored incrementor (return) value.
+	 * @param  int   $expected_incrementor The expected final incrementor value.
+	 *
+	 * @return void
 	 */
-	public function test___construct() {
-		$transients = m::mock( Transients::class )->shouldAllowMockingProtectedMethods()->makePartial()
-			->shouldReceive( 'get' )->once()->with( 'some_prefix_transients_incrementor', true )->andReturn( 0 )
-			->shouldReceive( 'invalidate' )->once()
-			->getMock();
+	public function test___construct( $stored_incrementor, int $expected_incrementor ) {
+		$transients = m::mock( Transients::class )->shouldAllowMockingProtectedMethods()->makePartial();
+		$transients->shouldReceive( 'get' )->once()->with( 'some_prefix_transients_incrementor', true )->andReturn( $stored_incrementor );
+		$transients->shouldReceive( 'invalidate' )->times( 0 === $expected_incrementor ? 1 : 0 );
+
 		$transients->__construct( 'some_prefix_' );
 
 		$this->assertInstanceOf( Transients::class, $transients );
+		$this->assert_attribute_same( $expected_incrementor, 'incrementor', $transients );
 	}
 
 	/**

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -134,11 +134,6 @@ class Transients_Test extends TestCase {
 		$dummy_result = [ [ 'option_name' => Transients::TRANSIENT_SQL_PREFIX . 'typo_foobar' ] ];
 
 		global $wpdb;
-
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
-
 		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->options = 'wp_options';
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );
@@ -157,11 +152,6 @@ class Transients_Test extends TestCase {
 	 */
 	public function test_get_keys_from_database_no_transients() {
 		global $wpdb;
-
-		if ( ! defined( 'ARRAY_A' ) ) {
-			define( 'ARRAY_A', 'array' );
-		}
-
 		$wpdb          = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->options = 'wp_options';
 		$this->transients->shouldReceive( 'get_prefix' )->once()->andReturn( self::PREFIX );


### PR DESCRIPTION
- Increases PHPStan level to `max`.
- Adds additional type declrations.
- Handles empty transient lists.
- Makes stored incrementor handling more resilient.