### PR TITLE
fix getting cached incrementor

### DIFF
--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -59,7 +59,7 @@ class Cache extends Abstract_Cache {
 		$this->incrementor_key = "{$prefix}cache_incrementor";
 
 		$incrementor = \wp_cache_get( $this->incrementor_key, $this->group );
-		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
+		$incrementor = \intval( $incrementor ) ? $incrementor : 0;
 
 		$this->incrementor = $incrementor;
 

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -57,8 +57,7 @@ class Transients extends Abstract_Cache {
 		$this->incrementor_key = $prefix . 'transients_incrementor';
 
 		$incrementor = $this->get( $this->incrementor_key, true );
-		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
-
+		$incrementor = \intval( $incrementor ) ? $incrementor : 0;
 		$this->incrementor = $incrementor;
 
 		parent::__construct( $prefix );


### PR DESCRIPTION
when a redis cache is used, the returned value is an integer stored as a string so the test for is_int would always fail. Use intval to fix this