### PR TITLE
Fix cache invalidation

### DIFF
--- a/src/class-cache.php
+++ b/src/class-cache.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2024 Peter Putzer.
+ * Copyright 2017-2026 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -57,11 +57,7 @@ class Cache extends Abstract_Cache {
 
 		$this->group           = ! isset( $group ) ? $prefix : $group;
 		$this->incrementor_key = "{$prefix}cache_incrementor";
-
-		$incrementor = \wp_cache_get( $this->incrementor_key, $this->group );
-		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
-
-		$this->incrementor = $incrementor;
+		$this->incrementor     = \filter_var( \wp_cache_get( $this->incrementor_key, $this->group ), \FILTER_VALIDATE_INT, \FILTER_NULL_ON_FAILURE ) ?? 0;
 
 		parent::__construct( $prefix );
 	}

--- a/src/class-transients.php
+++ b/src/class-transients.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2024 Peter Putzer.
+ * Copyright 2017-2026 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -55,11 +55,7 @@ class Transients extends Abstract_Cache {
 	 */
 	public function __construct( string $prefix ) {
 		$this->incrementor_key = $prefix . 'transients_incrementor';
-
-		$incrementor = $this->get( $this->incrementor_key, true );
-		$incrementor = \is_int( $incrementor ) ? $incrementor : 0;
-
-		$this->incrementor = $incrementor;
+		$this->incrementor     = \filter_var( $this->get( $this->incrementor_key, true ), \FILTER_VALIDATE_INT, \FILTER_NULL_ON_FAILURE ) ?? 0;
 
 		parent::__construct( $prefix );
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2018-2024 Peter Putzer.
+ * Copyright 2018-2026 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,7 +21,7 @@
  * @package mundschenk-at/wp-data-storage/tests
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  *
- * @version 2.0.0
+ * @version 2.0.1
  */
 
 /**

--- a/tests/class-cache-test.php
+++ b/tests/class-cache-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2024 Peter Putzer.
+ * Copyright 2017-2026 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -71,7 +71,9 @@ class Cache_Test extends TestCase {
 	 */
 	public function provide_test__construct_data(): array {
 		return [
-			'valid stored incrementor' => [ 55, 55 ],
+			'valid, stored as int'     => [ 55, 55 ],
+			'valid, stored as string'  => [ '55', 55 ],
+			'float, stored as string'  => [ '55.5', 0 ],
 			'no stored incrementor'    => [ false, 0 ],
 			'empty string'             => [ '', 0 ],
 			'non-empty string'         => [ 'something', 0 ],

--- a/tests/class-transients-test.php
+++ b/tests/class-transients-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of mundschenk-at/wp-data-storage.
  *
- * Copyright 2017-2024 Peter Putzer.
+ * Copyright 2017-2026 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -73,7 +73,9 @@ class Transients_Test extends TestCase {
 	 */
 	public function provide_test__construct_data(): array {
 		return [
-			'valid stored incrementor' => [ 55, 55 ],
+			'valid, stored as int'     => [ 55, 55 ],
+			'valid, stored as string'  => [ '55', 55 ],
+			'float, stored as string'  => [ '55.5', 0 ],
 			'no stored incrementor'    => [ false, 0 ],
 			'empty string'             => [ '', 0 ],
 			'non-empty string'         => [ 'something', 0 ],


### PR DESCRIPTION
Fixes the cache invalidation behavior when used with object cache implementations that store all scalar values as `string`. 

Supersedes #10.